### PR TITLE
新增「活動主辦者驗證」 middleware

### DIFF
--- a/src/controllers/activityController.ts
+++ b/src/controllers/activityController.ts
@@ -8,15 +8,8 @@ import { validateInput } from "../utils/validateInput";
 
 // 取得特定活動的票種資料
 export const getActivityTicketTypes = async (req: Request, res: Response, next: NextFunction) => {
-  if (!req.user) {
-    return next({
-      message: "未登入或無效 token",
-      statusCode: 401,
-    });
-  }
-
   try {
-    const { activityId } = validateInput(activityIdSchema, req.params);
+    const activityId = validateInput(activityIdSchema, req.params.activityId);
 
     const activity = await activityService.getActivityById(activityId);
     if (!activity) {
@@ -69,7 +62,7 @@ export const getActivity = async (
   next: NextFunction,
 ): Promise<void> => {
   try {
-    const { activityId } = validateInput(activityIdSchema, req.params);
+    const activityId = validateInput(activityIdSchema, req.params.activityId);
     const userId = req.user?.id || 0;
     const activity = await activityService.getActivityDetails(activityId, userId);
     if (!activity) {

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -51,13 +51,6 @@ export const auth = async (req: Request, res: Response, next: NextFunction): Pro
     const user = await prisma.user.findUnique({
       where: { id: decoded.id },
     });
-
-    // 查詢用戶的主辦者ID
-    const organizerIds = await prisma.organizer.findMany({
-      where: { userId: decoded.id },
-      select: { id: true },
-    });
-
     if (!user) {
       res.status(401).json({
         message: "無效的令牌，用戶不存在",
@@ -65,6 +58,12 @@ export const auth = async (req: Request, res: Response, next: NextFunction): Pro
       });
       return;
     }
+
+    // 查詢用戶的主辦者ID
+    const organizerIds = await prisma.organizer.findMany({
+      where: { userId: decoded.id },
+      select: { id: true },
+    });
 
     // 將用戶資訊附加到請求對象
     req.user = {
@@ -118,11 +117,6 @@ export const optionalAuth = async (
     const user = await prisma.user.findUnique({
       where: { id: decoded.id },
     });
-    const organizerIds = await prisma.organizer.findMany({
-      where: { userId: decoded.id },
-      select: { id: true },
-    });
-
     if (!user) {
       res.status(401).json({
         message: "無效的令牌，用戶不存在",
@@ -130,6 +124,11 @@ export const optionalAuth = async (
       });
       return;
     }
+
+    const organizerIds = await prisma.organizer.findMany({
+      where: { userId: decoded.id },
+      select: { id: true },
+    });
 
     req.user = {
       id: user.id,

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -15,7 +15,7 @@ declare global {
       user?: {
         id: number;
         email: string;
-        organizerId?: number; // 可選屬性，主辦者身份驗證為真時使用
+        organizerId?: number;
       };
     }
   }
@@ -151,7 +151,6 @@ export const activityOrganizerAuth = async (
     const { id: userId } = req.user;
     const { organizerId } = retrievedActivity;
 
-    // 查詢用戶是否為主辦者
     const organizer = await prisma.organizer.findFirst({
       where: {
         id: organizerId,
@@ -168,7 +167,7 @@ export const activityOrganizerAuth = async (
 
     req.user = {
       ...req.user,
-      organizerId: organizer.id, // 將主辦者ID附加到請求對象
+      organizerId: organizer.id,
     };
 
     next();

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -75,7 +75,22 @@ export const auth = async (req: Request, res: Response, next: NextFunction): Pro
 
     next();
   } catch (error) {
-    // 略過token解析錯誤
+    if (error instanceof jwt.JsonWebTokenError) {
+      res.status(401).json({
+        message: "無效的令牌",
+        status: false,
+      });
+      return;
+    }
+
+    if (error instanceof jwt.TokenExpiredError) {
+      res.status(401).json({
+        message: "令牌已過期",
+        status: false,
+      });
+      return;
+    }
+
     next(error);
   }
 };
@@ -124,7 +139,22 @@ export const optionalAuth = async (
 
     next();
   } catch (error) {
-    // 略過token解析錯誤
+    if (error instanceof jwt.JsonWebTokenError) {
+      res.status(401).json({
+        message: "無效的令牌",
+        status: false,
+      });
+      return;
+    }
+
+    if (error instanceof jwt.TokenExpiredError) {
+      res.status(401).json({
+        message: "令牌已過期",
+        status: false,
+      });
+      return;
+    }
+
     next(error);
   }
 };

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -12,7 +12,7 @@ declare global {
       user?: {
         id: number;
         email: string;
-        organizerIds: { id: number }[];
+        organizerIds: number[];
       };
     }
   }
@@ -69,7 +69,7 @@ export const auth = async (req: Request, res: Response, next: NextFunction): Pro
     req.user = {
       id: user.id,
       email: user.email,
-      organizerIds,
+      organizerIds: organizerIds.map((organizer) => organizer.id),
     };
 
     next();
@@ -133,7 +133,7 @@ export const optionalAuth = async (
     req.user = {
       id: user.id,
       email: user.email,
-      organizerIds,
+      organizerIds: organizerIds.map((organizer) => organizer.id),
     };
 
     next();

--- a/src/routes/v1/activities.ts
+++ b/src/routes/v1/activities.ts
@@ -1,6 +1,6 @@
 import express from "express";
 import * as activityController from "../../controllers/activityController";
-import { auth, optionalAuth } from "../../middlewares/auth";
+import { optionalAuth } from "../../middlewares/auth";
 const router = express.Router();
 
 // router.get("/popular", () => {}); // 取得熱門活動
@@ -149,7 +149,7 @@ router.get("/", activityController.getActivities); // 取得活動資料
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  */
-router.get("/:activityId/ticketTypes", auth, activityController.getActivityTicketTypes);
+router.get("/:activityId/ticketTypes", activityController.getActivityTicketTypes);
 
 // router.get("/:activityId/participants", () => {}); // 取得活動參加名單
 

--- a/src/schemas/zod/activity.schema.ts
+++ b/src/schemas/zod/activity.schema.ts
@@ -1,31 +1,12 @@
 import { z } from "zod";
 
 // 活動 id 驗證
-export const activityIdSchema = z.object({
-  activityId: z.string().transform((val, ctx) => {
-    const parsed = Number(val);
-
-    if (Number.isNaN(parsed)) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "活動 id 格式錯誤",
-      });
-
-      return z.NEVER;
-    }
-
-    if (parsed <= 0) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "活動 id 必須大於 0",
-      });
-
-      return z.NEVER;
-    }
-
-    return parsed;
-  }),
-});
+export const activityIdSchema = z.coerce
+  .number({
+    invalid_type_error: "活動 id 格式錯誤",
+    required_error: "活動 id 為必要欄位",
+  })
+  .min(1, "活動 id 必須大於 0");
 
 // 取得活動資料Query
 export const activityQuerySchema = z.object({


### PR DESCRIPTION
## Story/Why
在許多的活動編輯動作會需要一直頻繁的驗證是否為該活動的主辦者，這樣會一直重複寫驗證

## Solution
新增這一個 middleware，利用 activityId 與 已經由 token 驗證的 userId 來做匹配，確認是否為該活動的主辦者。
故要使用這一個 middleware 之前一定要有 `auth` 的使用，不可為 `optionalAuth`

## Additional Note
有改變一下 `src/schemas/zod/activity.schema.ts` 的 `activityIdSchema`，之前的寫法會使這一個 schema 被到處 import 使用，因為之前都是 object，現在會 return number 就可以共用了