### PR TITLE
kai/fix/get-participant-response-spelling

### DIFF
--- a/src/routes/v1/activities.ts
+++ b/src/routes/v1/activities.ts
@@ -468,7 +468,7 @@ router.delete(
  *                 data:
  *                   type: array
  *                   items:
- *                     $ref: '#/components/schemas/getPartcipantResponse'
+ *                     $ref: '#/components/schemas/getParticipantResponse'
  *                 pagination:
  *                   $ref: '#/components/schemas/PaginationResponse'
  *       400:


### PR DESCRIPTION
## Story/Why
解決[這一個 issue](https://discord.com/channels/1348194165359640640/1363166207506907256/1379666534263423007)

## Solution
更改 getParticipantResponse 的命名