### PR TITLE
kai/hotfix/qrCodeToken-remove-unique

### DIFF
--- a/src/prisma/migrations/20250609140923_remove_unique_from_qrcode_token_field/migration.sql
+++ b/src/prisma/migrations/20250609140923_remove_unique_from_qrcode_token_field/migration.sql
@@ -1,0 +1,5 @@
+-- DropIndex
+DROP INDEX "tickets_qrCodeToken_key";
+
+-- AlterTable
+ALTER TABLE "orders" ALTER COLUMN "paidExpiredAt" SET DEFAULT now() + interval '10 minutes';

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -214,7 +214,7 @@ model Ticket {
   activityId     Int
   order          Order        @relation(fields: [orderId], references: [id])
   orderId        String
-  qrCodeToken    String       @unique
+  qrCodeToken    String
   checkInAt      DateTime?
   status         TicketStatus @default(unassigned)
   assignedUser   User?        @relation(fields: [assignedUserId], references: [id])


### PR DESCRIPTION
## Solution
發現在創建線上訂單時會有 qrCodeToken 重複的問題，而發生錯誤，所以要改為非 unique
