### PR TITLE
feat: add get checked in quantity api

### DIFF
--- a/src/controllers/activityController.ts
+++ b/src/controllers/activityController.ts
@@ -492,3 +492,29 @@ export const patchActivityType = async (req: Request, res: Response, next: NextF
     }
   }
 };
+
+// 取得報到人數
+export const getCheckedInResult = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const activityId = validateInput(activityIdSchema, req.params.activityId);
+    const activity = await activityService.getActivityById(activityId);
+    if (!activity) {
+      sendResponse(res, 404, "活動不存在", false);
+      return;
+    }
+
+    const isOrganization = req.user?.organizationIds.includes(activity.organizationId);
+    if (!isOrganization) {
+      sendResponse(res, 403, "無權限，非主辦單位成員", false);
+      return;
+    }
+    const result = await activityService.getCheckedInResult(activityId);
+    sendResponse(res, 200, "請求成功", true, result);
+  } catch (error) {
+    if (error instanceof InputValidationError) {
+      sendResponse(res, 400, error.message, false);
+    } else {
+      next(error);
+    }
+  }
+};

--- a/src/routes/v1/activities.ts
+++ b/src/routes/v1/activities.ts
@@ -574,6 +574,66 @@ router.get("/:activityId/income", auth, activityController.getIncome); // 取得
 
 /**
  * @swagger
+ * /api/v1/activities/{activityId}/checkedIn:
+ *   get:
+ *     tags:
+ *       - Activities
+ *     summary: 獲取特定活動的報到狀況
+ *     description: 獲取特定活動的詳細報到狀況，包含報到人數、活動狀態，checkedInCount= 報到人數、soldCount= 售出票券數量、totalTicketQuantity= 總票券數
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - name: activityId
+ *         in: path
+ *         description: 活動 ID
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: 請求成功
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: success
+ *                 status:
+ *                   type: boolean
+ *                   example: true
+ *                 data:
+ *                   $ref: '#/components/schemas/getCheckedInResponse'
+ *       400:
+ *         description: 格式錯誤
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: 未登入
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       403:
+ *         description: 無權限，非主辦單位成員
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       404:
+ *         description: 活動不存在
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+router.get("/:activityId/checkedIn", auth, activityController.getCheckedInResult);
+
+/**
+ * @swagger
  * /api/v1/activities/{activityId}:
  *   get:
  *     tags:

--- a/src/schemas/swagger/activties.schema.ts
+++ b/src/schemas/swagger/activties.schema.ts
@@ -437,4 +437,32 @@
  *               amount:
  *                 type: number
  *                 example: 500
+ *     # 活動詳細報到資料結構
+ *     # -----------------------------------------------
+ *     getCheckedInResponse:
+ *       type: object
+ *       properties:
+ *         isOnline:
+ *           type: boolean
+ *           example: true
+ *         status:
+ *           type: string
+ *           example: published
+ *         startTime:
+ *           type: string
+ *           example: 2025-05-01T10:00:00Z
+ *           format: date
+ *         endTime:
+ *           type: string
+ *           example: 2025-05-01T18:00:00Z
+ *           format: date
+ *         checkedInCount:
+ *           type: number
+ *           example: 5
+ *         soldCount:
+ *           type: number
+ *           example: 10
+ *         totalTicketQuantity:
+ *           type: number
+ *           example: 15
  */

--- a/src/schemas/swagger/activties.schema.ts
+++ b/src/schemas/swagger/activties.schema.ts
@@ -444,25 +444,32 @@
  *       properties:
  *         isOnline:
  *           type: boolean
+ *           description: 是否為線上活動
  *           example: true
  *         status:
  *           type: string
+ *           description: 活動當前狀態
  *           example: published
  *         startTime:
  *           type: string
+ *           description: 活動開始時間
  *           example: 2025-05-01T10:00:00Z
  *           format: date
  *         endTime:
  *           type: string
+ *           description: 活動結束時間
  *           example: 2025-05-01T18:00:00Z
  *           format: date
  *         checkedInCount:
  *           type: number
+ *           description: 已報到人數
  *           example: 5
  *         soldCount:
  *           type: number
+ *           description: 已售票張數
  *           example: 10
  *         totalTicketQuantity:
  *           type: number
+ *           description: 總票數
  *           example: 15
  */

--- a/src/utils/emailClient.ts
+++ b/src/utils/emailClient.ts
@@ -92,7 +92,7 @@ export const sendActivityCancelEmail = async (
           <h2>活動取消通知</h2>
           <p>您好 ${name}，</p>
           <p>您所報名參加的活動 <strong>${activityTitle}</strong> 已被取消。</p>
-          <p>若您已付款，請聯繫客服處理退款作業。</p>
+          <p>若您已付款，請留意退款信件，若未收到，再請聯繫客服處理。</p>
           <p>謝謝您的支持與理解。</p>
           <p>Eventa 團隊</p>
         </div>

--- a/src/utils/emailClient.ts
+++ b/src/utils/emailClient.ts
@@ -75,3 +75,34 @@ export const sendGoogleLoginEmail = async (email: string, name: string): Promise
     return false;
   }
 };
+
+// 活動取消通知
+export const sendActivityCancelEmail = async (
+  email: string,
+  name: string,
+  activityTitle: string,
+): Promise<boolean> => {
+  try {
+    const mailOptions = {
+      from: `Eventa <${process.env.EMAIL_USER}>`,
+      to: email,
+      subject: "Eventa - 活動取消通知",
+      html: `
+        <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+          <h2>活動取消通知</h2>
+          <p>您好 ${name}，</p>
+          <p>您所報名參加的活動 <strong>${activityTitle}</strong> 已被取消。</p>
+          <p>若您已付款，請聯繫客服處理退款作業。</p>
+          <p>謝謝您的支持與理解。</p>
+          <p>Eventa 團隊</p>
+        </div>
+      `,
+    };
+
+    await transporter.sendMail(mailOptions);
+    return true;
+  } catch (error) {
+    console.error("發送活動取消通知郵件失敗:", error);
+    return false;
+  }
+};


### PR DESCRIPTION
## Story/Why
新增取得報到詳情API，用來取得下方圖片中的資料

![image](https://github.com/user-attachments/assets/0cc0699c-4ba2-45f9-9446-e4554e1d89d6)

## Solution
1. 新增API，詳請參考swagger文件
2. 順便補強取消活動的邏輯，如已有訂單的活動會發取消通知信件給使用者

## Additional Note
避免tickets數量太多占用記憶體，所以用再操作一次DB的方式計算票數