### PR TITLE
kai/fix/get-order-demand

### DIFF
--- a/src/services/orderService.ts
+++ b/src/services/orderService.ts
@@ -168,7 +168,7 @@ export const getOrders = async (userId: number, queries: OrderQuerySchema) => {
     const toDate = dayjs(to).toDate();
 
     where.activity = {
-      ...where.activity,
+      ...(where.activity || {}),
       OR: [
         {
           startTime: {


### PR DESCRIPTION
## Story/Why
處理以下對話的需求：
[訂單管理頁的時間搜尋需要對上活動的起迄時間](https://discord.com/channels/1348194165359640640/1382256197561749524/1382619796125913099)
[訂單詳情需要多活動的 id，以利回到活動付款頁面](https://discord.com/channels/1348194165359640640/1382256197561749524/1382651508759203931)

## Solution
新學到 OR 的使用！太讚了
