### PR TITLE
增加訂單退款功能及相關狀態更新

### DIFF
--- a/src/prisma/migrations/20250615082326_update_order_status_with_refunded/migration.sql
+++ b/src/prisma/migrations/20250615082326_update_order_status_with_refunded/migration.sql
@@ -1,0 +1,5 @@
+-- AlterEnum
+ALTER TYPE "OrderStatus" ADD VALUE 'refunded';
+
+-- AlterTable
+ALTER TABLE "orders" ALTER COLUMN "paidExpiredAt" SET DEFAULT now() + interval '10 minutes';

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -32,6 +32,7 @@ enum OrderStatus {
   expired
   canceled
   failed
+  refunded
 }
 
 enum InvoiceType {

--- a/src/routes/v1/orders.ts
+++ b/src/routes/v1/orders.ts
@@ -380,4 +380,65 @@ router.post("/:orderId/checkout", auth, orderController.checkoutOrder);
  */
 router.get("/:orderId/checkout/result", auth, orderController.getCheckoutResult);
 
+/**
+ * @swagger
+ * /api/v1/orders/{orderId}/refund:
+ *   post:
+ *     tags:
+ *       - Orders
+ *     summary: 訂單退款
+ *     description: 用來退款訂單
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: orderId
+ *         required: true
+ *         schema:
+ *           type: string
+ *           example: "O25053115453487373"
+ *     responses:
+ *       201:
+ *         description: 退款成功
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: 退款成功
+ *                 status:
+ *                   type: boolean
+ *                   example: true
+ *               data:
+ *                 type: object
+ *                 properties:
+ *                   orderId:
+ *                     type: string
+ *                     example: "O25053115453487373"
+ *                   status:
+ *                     type: string
+ *                     example: refunded
+ *       401:
+ *         description: 未提供授權令牌
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       404:
+ *         description: 訂單不存在
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       409:
+ *         description: 只能退款已付款的訂單
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+router.post("/:orderId/refund", auth, orderController.refundOrder);
+
 export default router;

--- a/src/services/orderService.ts
+++ b/src/services/orderService.ts
@@ -606,7 +606,7 @@ export const refundOrder = async (orderId: string) => {
         payment: {
           update: {
             data: {
-              rawData: "退款",
+              rawData: OrderStatus.refunded,
             },
           },
         },

--- a/src/services/orderService.ts
+++ b/src/services/orderService.ts
@@ -622,17 +622,18 @@ export const refundOrder = async (orderId: string) => {
       },
     });
 
-    const { orderItems } = refundedOrder;
-    for (const { ticketTypeId, quantity } of orderItems) {
-      await tx.ticketType.update({
-        where: { id: ticketTypeId },
-        data: {
-          remainingQuantity: {
-            increment: quantity,
+    await Promise.all(
+      refundedOrder.orderItems.map(({ ticketTypeId, quantity }) =>
+        tx.ticketType.update({
+          where: { id: ticketTypeId },
+          data: {
+            remainingQuantity: {
+              increment: quantity,
+            },
           },
-        },
-      });
-    }
+        }),
+      ),
+    );
 
     return refundedOrder.status;
   });

--- a/src/services/orderService.ts
+++ b/src/services/orderService.ts
@@ -605,7 +605,6 @@ export const refundOrder = async (orderId: string) => {
         },
         payment: {
           update: {
-            where: { orderId },
             data: {
               rawData: "退款",
             },


### PR DESCRIPTION
## Story/Why
[[API] 申請退款(送出退款資訊)(目前先不串金流)](https://trello.com/c/0ez8oIFX/45-api-%E7%94%B3%E8%AB%8B%E9%80%80%E6%AC%BE%E9%80%81%E5%87%BA%E9%80%80%E6%AC%BE%E8%B3%87%E8%A8%8A%E7%9B%AE%E5%89%8D%E5%85%88%E4%B8%8D%E4%B8%B2%E9%87%91%E6%B5%81)

## Solution
因為目前不處理金流，再加上後續的討論不再用 票券 作為退票依據，
所以直接不使用 refund table，故沒有看到新增 refund 的部份。

## 測試方式
新增一筆訂單後，到 database 將其改為 `paid` 後，即可把該訂單的 id 用來 post /api/v1/orders/:orderId/refund 測試
