### PR TITLE
支援免費票的訂單創建與處理邏輯

### DIFF
--- a/src/controllers/orderController.ts
+++ b/src/controllers/orderController.ts
@@ -49,6 +49,7 @@ export const createOrder = async (req: Request, res: Response, next: NextFunctio
     let totalAmount = new Prisma.Decimal(0);
     const ticketTypeMap = new Map(ticketTypes.map((type) => [type.id, type]));
     const seenTicketIds = new Set();
+    let isAllFreeTickets = false;
 
     for (const ticket of tickets) {
       if (ticket.quantity <= 0) {
@@ -93,6 +94,10 @@ export const createOrder = async (req: Request, res: Response, next: NextFunctio
       });
     }
 
+    if (totalAmount.isZero()) {
+      isAllFreeTickets = true;
+    }
+
     const {
       invoiceAddress,
       invoiceTitle,
@@ -103,7 +108,7 @@ export const createOrder = async (req: Request, res: Response, next: NextFunctio
       invoiceCarrier,
       invoiceType,
       ...restData
-    } = await orderService.createOrder(req.user.id, validatedData);
+    } = await orderService.createOrder(req.user.id, validatedData, isAllFreeTickets);
 
     res.status(201).json({
       message: "訂單創建成功",

--- a/src/utils/paymentTypes.ts
+++ b/src/utils/paymentTypes.ts
@@ -29,4 +29,5 @@ export const PaymentTypes: { [key: string]: string } = {
   Flexible_Installment: "圓夢彈性分期",
   TWQR_OPAY: "歐付寶TWQR 行動支付",
   BNPL_URICH: "裕富數位無卡分期",
+  FREE: "免費",
 };


### PR DESCRIPTION
## Story/Why
[訂單僅有免費票時要直接略過付款](https://www.notion.so/2136a246851880e6ac49c205b42196c6?source=copy_link)

## Solution
多加一個 `isAllFreeTickets` 來判斷是否為全免費票狀況，如果是就會直接設定 order 為 paid，及其他相關的值

## Additional Note
- 發現 `utc().toISOString()` 與 單用 `toISOString` 是一樣，所以就優化
- 在創建訂單時，時間用 now cached 住，確保一致性
