### PR TITLE
fix: cors origin

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -24,7 +24,7 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use(
   cors({
-    origin: "*",
+    origin: process.env.EVENTA_FRONTEND_URL,
     methods: ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
     credentials: true,
   }),
@@ -45,5 +45,5 @@ app.use(errorHandler);
 setupSchedulers();
 
 app.listen(PORT, () => {
-  console.log(`Server is running at http://127.0.0.1:${PORT}`);
+  console.log(`Server is running at ${process.env.EVENTA_BACKEND_URL}`);
 });


### PR DESCRIPTION
## Story/Why
Linked Trello: (對應 Trello 卡片之連結)
測試時有發現cors錯誤

```
Access to fetch at 'https://eventa-backend-pgun.onrender.com/api/v1/activities/44/content' from origin 'https://eventa-frontend.onrender.com' 
has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

## Solution
指定cors來源為環境變數中的前端網址

## Additional Note
順便將server啟動時的console內容修改
