### PR TITLE
Kai/fix/from notion

### DIFF
--- a/src/controllers/ticketController.ts
+++ b/src/controllers/ticketController.ts
@@ -1,4 +1,5 @@
 import { TicketStatus } from "@prisma/client";
+import dayjs from "dayjs";
 import type { NextFunction, Request, Response } from "express";
 import { InputValidationError } from "../errors/InputValidationError";
 import { ticketIdSchema } from "../schemas/zod/ticket.schema";
@@ -10,8 +11,20 @@ export const patchTicketUsed = async (req: Request, res: Response, next: NextFun
   try {
     const data = validateInput(ticketIdSchema, req.params.ticketId);
     const ticket = await ticketService.getTicketById(data);
+    const now = dayjs().utc();
+
     if (!ticket) {
       sendResponse(res, 404, "票券不存在", false);
+      return;
+    }
+
+    if (now.isBefore(ticket.activity.startTime)) {
+      sendResponse(res, 400, "活動尚未開始，無法報到", false);
+      return;
+    }
+
+    if (now.isAfter(ticket.activity.endTime)) {
+      sendResponse(res, 400, "活動已結束，無法報到", false);
       return;
     }
 

--- a/src/controllers/ticketTypeController.ts
+++ b/src/controllers/ticketTypeController.ts
@@ -69,22 +69,16 @@ export const createTicketTypes = async (req: Request, res: Response, next: NextF
         });
       }
 
-      const creatingTicketTypeStartTime = creatingTicketType.saleStartAt
-        ? dayjs(creatingTicketType.saleStartAt).utc()
-        : dayjs(creatingTicketType.startTime).utc();
-      const creatingTicketTypeEndTime = creatingTicketType.saleEndAt
-        ? dayjs(creatingTicketType.saleEndAt).utc()
-        : dayjs(creatingTicketType.endTime).utc();
       const activityEndTime = dayjs(retrievedActivity.endTime).utc();
 
-      if (creatingTicketTypeStartTime.isAfter(activityEndTime)) {
+      if (dayjs(creatingTicketType.startTime).utc().isAfter(activityEndTime)) {
         return next({
           message: `第 ${i} 個新增票種的銷售開始時間不可晚於活動結束時間`,
           statusCode: 400,
         });
       }
 
-      if (creatingTicketTypeEndTime.isAfter(activityEndTime)) {
+      if (dayjs(creatingTicketType.endTime).utc().isAfter(activityEndTime)) {
         return next({
           message: `第 ${i} 個新增票種的銷售結束時間不可晚於活動結束時間`,
           statusCode: 400,
@@ -171,22 +165,16 @@ export const updateTicketType = async (req: Request, res: Response, next: NextFu
       });
     }
 
-    const updatingTicketTypeStartTime = validatedData.saleStartAt
-      ? dayjs(validatedData.saleStartAt).utc()
-      : dayjs(validatedData.startTime).utc();
-    const updatingTicketTypeEndTime = validatedData.saleEndAt
-      ? dayjs(validatedData.saleEndAt).utc()
-      : dayjs(validatedData.endTime).utc();
     const activityEndTime = dayjs(retrievedActivity.endTime).utc();
 
-    if (updatingTicketTypeStartTime.isAfter(activityEndTime)) {
+    if (dayjs(validatedData.startTime).utc().isAfter(activityEndTime)) {
       return next({
         message: "票種的銷售開始時間不可晚於活動結束時間",
         statusCode: 400,
       });
     }
 
-    if (updatingTicketTypeEndTime.isAfter(activityEndTime)) {
+    if (dayjs(validatedData.endTime).utc().isAfter(activityEndTime)) {
       return next({
         message: "票種的銷售結束時間不可晚於活動結束時間",
         statusCode: 400,

--- a/src/routes/v1/activities.ts
+++ b/src/routes/v1/activities.ts
@@ -333,7 +333,7 @@ router.post("/:activityId/ticketTypes", auth, ticketTypeController.createTicketT
  *                   type: boolean
  *                   example: true
  *       400:
- *         description: 格式錯誤、票種名稱已存在，請使用其他名稱、票種的銷售開始時間不可晚於活動結束時間、票種的銷售結束時間不可晚於活動結束時間
+ *         description: 格式錯誤、票種名稱已存在，請使用其他名稱、票種的銷售開始時間不可晚於活動結束時間、票種的銷售結束時間不可晚於活動結束時間、該票種已經有票券被使用或分配，無法編輯、該票種已經有票券被使用或分配，無法刪除
  *         content:
  *           application/json:
  *             schema:

--- a/src/routes/v1/tickets.ts
+++ b/src/routes/v1/tickets.ts
@@ -98,7 +98,7 @@ router.get("/:ticketId", auth, ticketController.getTicketDetails);
  *                       type: string
  *                       example: used
  *       400:
- *         description: 格式錯誤
+ *         description: 格式錯誤、活動尚未開始，無法報到、活動已結束，無法報到
  *         content:
  *           application/json:
  *             schema:

--- a/src/schemas/swagger/ticketTypes.schema.ts
+++ b/src/schemas/swagger/ticketTypes.schema.ts
@@ -47,18 +47,6 @@
  *           format: date
  *           description: 開賣結束時間，格式為 ISO 8601
  *           example: "2023-10-31T23:59:59Z"
- *         saleStartAt:
- *           type: string
- *           format: date
- *           description: 開賣時間，格式為 ISO 8601
- *           nullable: true
- *           example: "2023-10-01T00:00:00Z"
- *         saleEndAt:
- *           type: string
- *           format: date
- *           description: 開賣結束時間，格式為 ISO 8601
- *           nullable: true
- *           example: "2023-10-31T23:59:59Z"
  *         isActive:
  *           type: boolean
  *           description: 是否為活動中

--- a/src/schemas/zod/ticketType.schema.ts
+++ b/src/schemas/zod/ticketType.schema.ts
@@ -44,8 +44,6 @@ export const ticketTypeSchema = z
       required_error: "開賣結束時間 為必填欄位",
       invalid_type_error: "開賣結束時間 格式錯誤",
     }),
-    saleStartAt: z.coerce.date().nullish(),
-    saleEndAt: z.coerce.date().nullish(),
     isActive: z
       .boolean({
         required_error: "是否為啟動中 為必填欄位",

--- a/src/services/ticketService.ts
+++ b/src/services/ticketService.ts
@@ -11,6 +11,8 @@ export const getTicketById = async (ticketId: TicketId) => {
       activity: {
         select: {
           organizationId: true,
+          startTime: true,
+          endTime: true,
         },
       },
     },

--- a/src/services/ticketTypeService.ts
+++ b/src/services/ticketTypeService.ts
@@ -15,6 +15,9 @@ export const getTicketTypeById = async (ticketTypeId: number) => {
     where: {
       id: ticketTypeId,
     },
+    include: {
+      tickets: true,
+    },
   });
 };
 


### PR DESCRIPTION
## Story/Why
[編輯活動 票券設定 已賣出 的票券應該無法編輯以及刪除](https://www.notion.so/2166a24685188074a147eea70e97fb05?source=copy_link)
- 目前 編輯票券 未考慮到 已有賣出票的 票券 不應該可以刪除或者編輯時間等資訊
- [ ] 預期：已有賣出票 的票券 不得編輯或刪除

[參與者名單報到未限制時間需要活動時間內](https://www.notion.so/2186a246851880ac868bc285ac1001ac?source=copy_link)
- 目前報到沒有限制報到需在活動時間內
- [ ] 預期：實際活動尚未開始按下報到應該顯示相關錯誤說明不再活動時間內

## Solution
建議使用「免費票」來測試，然後要留意時間，因為時間需要用 utc time
