### PR TITLE
fix: password zod schema

### DIFF
--- a/src/schemas/zod/user.schema.ts
+++ b/src/schemas/zod/user.schema.ts
@@ -1,11 +1,18 @@
 import { z } from "zod";
 
+const passwordSchema = z
+  .string()
+  .regex(
+    /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[A-Za-z\d]{8,16}$/,
+    "密碼需為 8~16 字元，且包含大寫、小寫英文字母與數字，不能含特殊符號",
+  );
+
 // 用戶註冊驗證結構
 export const signupSchema = z
   .object({
     email: z.string().email("請提供有效的電子郵件地址"),
-    password: z.string().min(8, "密碼必須至少有8個字符").max(100),
-    checkPassword: z.string(),
+    password: passwordSchema,
+    checkPassword: z.string().min(8, "密碼必須至少8個字元").max(16, "密碼最多16個字元"),
   })
   .refine((data) => data.password === data.checkPassword, {
     message: "密碼和確認密碼必須相同",
@@ -26,8 +33,8 @@ export const forgetSchema = z.object({
 // 重設密碼確認驗證結構
 export const resetPasswordSchema = z
   .object({
-    newPassword: z.string().min(8, "密碼必須至少有8個字符").max(100),
-    confirmNewPassword: z.string().min(8, "請確認您的新密碼"),
+    newPassword: passwordSchema,
+    confirmNewPassword: z.string().min(8, "密碼必須至少8個字元").max(16, "密碼最多16個字元"),
     resetToken: z.string().min(1, "重設令牌不能為空"),
   })
   .refine((data) => data.newPassword === data.confirmNewPassword, {


### PR DESCRIPTION
## Story/Why
後端密碼驗證規則，更改為：

> 限制至少 8-16 碼、需同時包含大小寫英文及數字、不接受特殊符號

