### PR TITLE
fix: add tags to OR condition in keyword search

### DIFF
--- a/src/services/activityService.ts
+++ b/src/services/activityService.ts
@@ -44,7 +44,11 @@ export const getActivities = async (params: ActivityQueryParams) => {
   if (endTime) where.endTime = { lte: endTime };
   if (organizationId) where.organizationId = organizationId;
   if (keyword) {
-    where.OR = [{ title: { contains: keyword } }, { descriptionMd: { contains: keyword } }];
+    where.OR = [
+      { title: { contains: keyword } },
+      { descriptionMd: { contains: keyword } },
+      { tags: { contains: keyword } },
+    ];
   }
 
   const offset = paginator.getOffset(page, limit);


### PR DESCRIPTION
## Story/Why
發現點擊活動詳情內的tag時，跑到搜尋頁面沒有顯示資料
補上keyword會比對tags的條件

<img width="911" alt="image" src="https://github.com/user-attachments/assets/28791cb0-de2f-4341-932c-9a3be69c4297" />

<img width="871" alt="image" src="https://github.com/user-attachments/assets/2ca8b7b5-641e-4eb4-b82d-1c714240ffb6" />
