### PR TITLE
fix: add organization data in getActivity response

### DIFF
--- a/src/routes/v1/activities.ts
+++ b/src/routes/v1/activities.ts
@@ -659,7 +659,7 @@ router.get("/:activityId/checkedIn", auth, activityController.getCheckedInResult
  *               properties:
  *                 message:
  *                   type: string
- *                   example: 編輯成功
+ *                   example: 請求成功
  *                 status:
  *                   type: boolean
  *                   example: true

--- a/src/schemas/swagger/activties.schema.ts
+++ b/src/schemas/swagger/activties.schema.ts
@@ -122,6 +122,24 @@
  *             isRegistered:
  *               type: boolean
  *               example: true
+ *         organization:
+ *           type: object
+ *           properties:
+ *             id:
+ *               type: number
+ *               example: 1
+ *             name:
+ *               type: string
+ *               example: 活動主辦單位
+ *             avatar:
+ *               type: string
+ *               example: http://example.com/avatar.jpg
+ *             email:
+ *               type: string
+ *               example: 1w0Q2@example.com
+ *             officialSiteUrl:
+ *               type: string
+ *               example: https://example.com
  *     # 新增一筆活動資料結構
  *     # -----------------------------------------------
  *     CreateActivityRequest:

--- a/src/services/activityService.ts
+++ b/src/services/activityService.ts
@@ -93,7 +93,14 @@ export const getActivityDetails = async (activityId: number, userId: number) => 
     },
     include: {
       organization: {
-        select: { userId: true },
+        select: {
+          id: true,
+          userId: true,
+          avatar: true,
+          email: true,
+          name: true,
+          officialSiteUrl: true,
+        },
       },
       _count: {
         select: {
@@ -140,7 +147,6 @@ export const getActivityDetails = async (activityId: number, userId: number) => 
   }
 
   const { _count, activityLike, orders, organization, ...activity } = activityRaw;
-
   return {
     ...activity,
     tags: activity.tags?.split(",") || [],
@@ -148,6 +154,13 @@ export const getActivityDetails = async (activityId: number, userId: number) => 
     userStatus: {
       isFavorite: activityLike.length > 0,
       isRegistered: orders.length > 0,
+    },
+    organization: {
+      id: organization.id,
+      name: organization.name,
+      avatar: organization.avatar,
+      email: organization.email,
+      officialSiteUrl: organization.officialSiteUrl,
     },
   };
 };


### PR DESCRIPTION
## Story/Why
[DC問題討論紀錄](https://discord.com/channels/1348194165359640640/1350699666089574482/1386892644487139358)

解決未登入時，活動詳情無法獲取正確主辦資訊問題
