### PR TITLE
fix: get participants api can not get the right pages issue

### DIFF
--- a/src/services/activityService.ts
+++ b/src/services/activityService.ts
@@ -1,6 +1,5 @@
 import { ActivityStatus, ActivityStep, OrderStatus, Prisma, TicketStatus } from "@prisma/client";
 import dayjs from "dayjs";
-import { promise } from "zod";
 import { InputValidationError } from "../errors/InputValidationError";
 import prisma from "../prisma/client";
 import type {
@@ -550,7 +549,6 @@ export const getParticipants = async (activityId: ActivityId, params: Pagination
     }),
   ]);
 
-  console.log(data.length, totalItems);
   const pagination = paginator.getPagination(totalItems, page, limit);
   return { data, pagination };
 };


### PR DESCRIPTION
## Story/Why
[Notion測試問題 參加者名單：回傳頁數只有第一頁](https://www.notion.so/2186a2468518808e89d1f6040c305372?source=copy_link)

發現提供給pagination的total參數有誤，應要提供該活動的所有參加者數量，誤寫成限制limit後的數量，故永遠都只有一頁

## Solution
增加一行計算此活動所有有效票種的計算
